### PR TITLE
docs(env): clarify acme DEFAULT_EMAIL vs per-container LETSENCRYPT_EMAIL

### DIFF
--- a/filemgr/.env.template
+++ b/filemgr/.env.template
@@ -1,4 +1,6 @@
-# nginx proxy config
+# nginx-proxy / acme-companion
+# Leave LETSENCRYPT_EMAIL empty when userver-web letsencrypt/.env sets DEFAULT_EMAIL once; duplicating
+# the same email on every backend breaks ACME registration (addresses get concatenated).
 VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=


### PR DESCRIPTION
Document that repeating the same email on many containers breaks ACME when using userver-web nginx-proxy / acme-companion (addresses get concatenated).

<!--
Please use the content below as a template for your pull request.
Feel free to remove sections that do not make sense.
-->

## Scope
<!-- Briefly describe all the changes with bullet points. -->

## Checklist :rotating_light:
<!-- Check all items that apply. -->
- [ ] My code follows the code style
- [ ] Added or updated tests as needed (`python manage.py test`)
- [ ] All lints and tests passed correctly locally
- [ ] I upgraded dependencies to the latest working version

:heart: Thank you!
